### PR TITLE
Fix wording consistency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Displaying data from external services in a pinned gist.
 
 - [bird-box](https://github.com/matchai/bird-box) - Update a pinned gist to contain the latest tweets of a Twitter user.
 - [waka-box](https://github.com/matchai/waka-box) - Update a pinned gist to contain your weekly WakaTime stats.
-- [strava-box](https://github.com/JohnPhamous/strava-box) - Update a gist to contain your YTD exercise metrics from Strava.
-- [music-box](https://github.com/jacc/music-box) - Update a gist to contain your weekly listening report on Last.fm.
+- [strava-box](https://github.com/JohnPhamous/strava-box) - Update a pinned gist to contain your YTD exercise metrics from Strava.
+- [music-box](https://github.com/jacc/music-box) - Update a pinned gist to contain your weekly listening report on Last.fm.
 
 ## GitHub
 


### PR DESCRIPTION
just nitpicking through the README, noticed that not all the lines have the `pinned` prefix before the gist. 