### PR TITLE
Added covid-box

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Displaying data from external services in a pinned gist.
 - [todoist-box](https://github.com/yohix/todoist-box) - Update a pinned gist to contain your Todoist stats.
 - [movie-box](https://github.com/LuisAlejandro/movie-box) - Update a pinned gist to contain your media center stats from Trakt.tv.
 - [productive-box](https://github.com/maxam2017/productive-box) - Update a pinned gist to contain your most productive hours during the day.
+- [covid-box](https://github.com/puf17640/covid-box) - Update a gist to contain global or country specific coronavirus stats.
 
 ## GitHub
 


### PR DESCRIPTION
So today I found the activity-box project and since I am one of the maintainers of the [NovelCOVID API](https://github.com/novelcovid/api) and wrote my own npm package for it, I figured I should make my own **covid-box** so people can keep their followers on github up to date.