### PR TITLE
Add github-stats-box to Github category

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Displaying more detailed GitHub user data in a pinned gist.
 - [activity-box](https://github.com/JasonEtco/activity-box) - Update a pinned gist to contain the latest activity of a GitHub user.
 - [gh-box](https://github.com/sciencepal/Gist_GHData) - Update a pinned gist to contain your GitHub profile data.
 - [productive-box](https://github.com/maxam2017/productive-box) - Update a pinned gist to contain your most productive hours during the day.
+- [github-stats-box](https://github.com/bokub/github-stats-box) - Update a pinned gist to contain your GitHub statistics.
 
 ## Resources
 


### PR DESCRIPTION
[Here is an example gist](https://gist.github.com/bokub/1cc900d92b9acc15786d7553b46a2cdf) created with github-stats-box