### PR TITLE
Adding `shodan-exposure-box` to External Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Displaying data from external services in a pinned gist.
 - [blog-box](https://github.com/Aveek-Saha/blog-box) - Update a pinned gist to show your latest dev.to blog post.
 - [medium-stat-box](https://github.com/kylemocode/medium-stat-box) - Update a pinned gist to show your medium stats and latest articles.
 - [hitokoto-box](https://github.com/greenhandatsjtu/hitokoto-box) - Update a pinned gist to contain a random hitokoto.
+- [shodan-exposure-box](https://github.com/ChrisCarini/shodan-exposure-box) - Update a pinned gist containing the top used ports as observed by [Shodan](https://www.shodan.io/).
 
 ## GitHub
 


### PR DESCRIPTION
# Links

**GitHub:** https://github.com/ChrisCarini/shodan-exposure-box
**Gist:** https://gist.github.com/ChrisCarini/0c0b8690e430b9fe4572f9c4a38811c1

# Sample Image

<img src="https://github.com/ChrisCarini/shodan-exposure-box/raw/main/images/shodan-port-usage-box.png" width=500px />