### PR TITLE
Fix: mdl-watching-box was deleted

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Displaying data from external services in a pinned gist.
     - [leetcode-solved-box](https://github.com/Pudding124/leetcode-solved-box) - Update a pinned gist to show leetcode solved problem.
     - [leetcode-skills-box](https://github.com/tbeachill/leetcode-skills-box) - Update a pinned gist to show your top leetcode skills.
 - [mal-box](https://github.com/jckli/mal-box) - Update a pinned gist to contain your latest activity from MyAnimeList.
-- [mdl-watching-box](https://github.com/facalz/mdl-watching-box) - Update a pinned gist to contain your currently watching.
 - [medium-stat-box](https://github.com/kylemocode/medium-stat-box) - Update a pinned gist to show your medium stats and latest articles.
 - [movie-box](https://github.com/LuisAlejandro/movie-box) - Update a pinned gist to contain your media center stats from Trakt.tv.
 - [music-box](https://github.com/jacc/music-box) - Update a pinned gist to contain your weekly listening report on Last.fm.


### PR DESCRIPTION
# Summary
Delete mdl-watching-box link

# Description
The link is giving 404 error
# Links
[mdl-watching-box](https://github.com/facalz/mdl-watching-box)

**GitHub Repo:** 
**Sample Gist:** 

# Screenshot of example gist
Not

# Checklist
<!-- (required)
If done, insert a `x` between the brackets (ie, `[x]`).
If not done, leave empty (ie, `[ ]`).
-->

- [x] List item follows expected format (e.g. `[example-box](link) - Update a pinned gist to contain...`)
- [x] Pull request title is useful and clear
- [x] Pull request template is filled out
- [x] Pull request contains a single addition only
