### PR TITLE
feat: add osu-box

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Displaying data from external services in a pinned gist.
 - [music-box](https://github.com/jacc/music-box) - Update a pinned gist to contain your weekly listening report on Last.fm.
 - [neko-box](https://github.com/RangerDigital/neko-box) - Update a pinned gist to contain the latest activity from AniList.
 - [netease-music-box](https://github.com/Leecason/netease-music-box) - Update a pinned gist to contain your weekly listening report on Netease Cloud Music.
+- [osu-box](https://github.com/AiverAiva/osu-box) - Update a pinned gist to display your osu! stats.
 - [playstation-box](https://github.com/Swilder-M/playstation-box) - Update a pinned gist to contain your PlayStation playtime leaderboard.
 - [rescue-box](https://github.com/joshghent/rescue-box) - Update a pinned gist to contain your daily productivity stats from RescueTime.
 - [shodan-exposure-box](https://github.com/ChrisCarini/shodan-exposure-box) - Update a pinned gist containing the top used ports as observed by [Shodan](https://www.shodan.io/).


### PR DESCRIPTION
# Summary
Update a pinned gist to show your osu! stats.

# Description
Update a pinned gist to show your osu! stats like accuracy, rank, country rank, etc.

# Links
**GitHub Repo:** https://github.com/AiverAiva/osu-box
**Sample Gist:** https://gist.github.com/AiverAiva/f53231aed6896f053ecbc32ba77b4973

# Screenshot of example gist
![example](https://github.com/matchai/awesome-pinned-gists/assets/43096905/10c6eec7-1828-43e1-8c69-fb4e71b9f32a)

# Checklist


- [x] List item follows expected format (e.g. `[example-box](link) - Update a pinned gist to contain...`)
- [x] Pull request title is useful and clear
- [x] Pull request template is filled out
- [x] Pull request contains a single addition only
