### PR TITLE
Add todoist-box back

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Displaying data from external services in a pinned gist.
 - [stackoverflow-stats-box](https://github.com/Pudding124/stackoverflow-stats-box) - Update a pinned gist to show stack overflow stats.
 - [steam-box](https://github.com/YouEclipse/steam-box) - Update a pinned gist to contain your Steam playtime leaderboard.
 - [strava-box](https://github.com/JohnPhamous/strava-box) - Update a pinned gist to contain your YTD exercise metrics from Strava.
+- [todoist-box](https://github.com/joshghent/todoist-box) - Update a pinned gist to contain your Todoist productivity stats
 - [toggl-box](https://github.com/tobimori/toggl-box) - Update a pinned gist to contain your weekly Toggl time tracking stats
 - [trivia-box](https://github.com/ChrisCarini/trivia-box) - Update a pinned gist with a daily trivia question from Open Trivia DB.
 - [typeracer-box](https://github.com/tobimori/typeracer-box) - Update a pinned gist to contain your latest TypeRacer races


### PR DESCRIPTION
# Summary
The original todoist box repo has disappeared now. But is maintained by myself. I've made a number of updates to fix it for the new Todoist API.

# Description
<!-- (required) -->

# Links
<!-- (required) -->

**GitHub Repo:** https://github.com/joshghent/todoist-box
**Sample Gist:** https://gist.github.com/joshghent/9e51b87ff10900cdebed007f30dc72d7

# Screenshot of example gist
<!-- (required) -->
<img width="375" alt="Screenshot 2023-10-31 at 10 03 31" src="https://github.com/matchai/awesome-pinned-gists/assets/2934976/e2f98b23-3340-4ce4-8a60-736b018ff6fc">

# Checklist
<!-- (required)
If done, insert a `x` between the brackets (ie, `[x]`).
If not done, leave empty (ie, `[ ]`).
-->

- [x] List item follows expected format (e.g. `[example-box](link) - Update a pinned gist to contain...`)
- [x] Pull request title is useful and clear
- [x] Pull request template is filled out
- [x] Pull request contains a single addition only
