### PR TITLE
feat: add `solvedac-box` to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Displaying data from external services in a pinned gist.
 - [rescue-box](https://github.com/joshghent/rescue-box) - Update a pinned gist to contain your daily productivity stats from RescueTime.
 - [shodan-exposure-box](https://github.com/ChrisCarini/shodan-exposure-box) - Update a pinned gist containing the top used ports as observed by [Shodan](https://www.shodan.io/).
 - [shortcut-box](https://github.com/artemnovichkov/shortcut-box) - Update a pinned gist to contain random IDE shortcut
+- [solvedac-box](https://github.com/abiriadev/solvedac-box) - Update a pinned gist to show [solved.ac](https://solved.ac) profile.
 - Spotify (https://spotify.com/)
     - [spotify-box](https://github.com/izayl/spotify-box) - Update a pinned gist to contain your weekly top tracks on Spotify.
     - [spotify-box](https://github.com/Aveek-Saha/spotify-box) - Update a pinned gist to show your weekly/monthly/all-time top Spotify tracks/artists.


### PR DESCRIPTION
# Summary
Add `abiriadev/solvedac-box` to the list

# Description
Solved.ac is a rating site for BOJ(Baekjoon Online Judge. Lot similar to Codeforce and LeetCode, but for Korean developers.). `solvedac-box` is an action to update pinned Gist automatically to contain solved.ac profile information.

# Links

**GitHub Repo:** [abiriadev/solvedac-box](https://github.com/abiriadev/solvedac-box)
**Sample Gist:** [💯 My Solved.ac Profile](https://gist.github.com/abiriadev/7f2692a91fbddcafd096d52d28f799c5)

# Screenshot of example gist

![](https://github.com/abiriadev/solvedac-box/raw/main/assets/box.png)

# Checklist

- [x] List item follows expected format (e.g. `[example-box](link) - Update a pinned gist to contain...`)
- [x] Pull request title is useful and clear
- [x] Pull request template is filled out
- [x] Pull request contains a single addition only
