### PR TITLE
feat: add recent-languages-box to GitHub Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Displaying more detailed GitHub user data in a pinned gist.
 - [activity-box](https://github.com/JasonEtco/activity-box) - Update a pinned gist to contain the latest activity of a GitHub user.
 - [github-stats-box](https://github.com/bokub/github-stats-box) - Update a pinned gist to contain your GitHub statistics.
 - [lang-box](https://github.com/inokawa/lang-box) - Update a pinned gist to contain languages of your recent commits in GitHub
+  - [recent-languages-box](https://github.com/liby/recent-languages-box) - A TypeScript + Bun rewrite of lang-box that updates a pinned gist with your recent GitHub commit language statistics. It offers improved type safety, customizability, and uses a more scientific approach to sorting languages.
 - [productive-box](https://github.com/maxam2017/productive-box) - Update a pinned gist to contain your most productive hours during the day.
 
 ## User Defined


### PR DESCRIPTION
# Summary

Adds [recent-languages-box](https://github.com/liby/recent-languages-box) to the awesome-pinned-gists project. [recent-languages-box](https://github.com/liby/recent-languages-box) is a TypeScript and Bun rewrite of [lang-box](https://github.com/inokawa/lang-box), offering improved type safety, enhanced customizability, and faster execution times. It is a tool to update a pinned gist with statistics on languages from your recent GitHub commits.

# Description
[recent-languages-box](https://github.com/liby/recent-languages-box) builds upon the original lang-box, refactoring it with TypeScript for better type safety and maintainability. It also utilizes Bun as the runtime, providing potential performance benefits, especially during development. This rewrite is designed with customization in mind, making it easier for developers to tailor the functionality to their specific needs.

In addition to the technical refactoring, this update also includes minor UI adjustments to prevent display issues, ensuring that all elements are rendered completely. Moreover, it fixes a bug where the percent calculation was incorrect in certain cases, leading to inaccurate sorting of languages.

For example, as shown in the screenshot below, Markdown is ranked first, which is very confusing.
<img width="445" alt="image" src="https://github.com/user-attachments/assets/ee44df3a-5a7d-41d7-8cdc-e790b14f35c8">

# Links
<!-- (required) -->

**GitHub Repo:** https://github.com/liby/recent-languages-box
**Sample Gist:** https://gist.github.com/liby/914dd217cecdc3bf27960be421c95850

# Screenshot of example gist
<!-- (required) -->
<img width="453" alt="image" src="https://github.com/user-attachments/assets/e3e203a4-f9fa-4128-b46b-7934fc009c28">

# Checklist
<!-- (required)
If done, insert a `x` between the brackets (ie, `[x]`).
If not done, leave empty (ie, `[ ]`).
-->

- [x] List item follows expected format (e.g. `[example-box](link) - Update a pinned gist to contain...`)
- [x] Pull request title is useful and clear
- [x] Pull request template is filled out
- [x] Pull request contains a single addition only
