### PR TITLE
feat: Add hackmd-box

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Displaying data from external services in a pinned gist.
 - [covid-box](https://github.com/puf17640/covid-box) - Update a gist to contain global or country specific coronavirus stats.
 - [douban-box](https://github.com/CodeDaraW/douban-box) - Update a pinned gist to contain the latest user status about books/movies/music from Douban.
 - [goodreads-box](https://github.com/mdluo/goodreads-box) - Update a pinned gist to show your currently reading books and progress on Goodreads.
+- [hackmd-box](https://github.com/tsen159/hackmd-box) - Update a pinned gist to show your latest HackMD notes.
 - [hitokoto-box](https://github.com/greenhandatsjtu/hitokoto-box) - Update a pinned gist to contain a random hitokoto.
 - [hoyolab-box](https://github.com/yangchang-n/HoYoLab-box) - Update a pinned gist to show your Genshin Impact / Honkai: Star Rail play stats.
 - LeetCode (https://leetcode.com/)


### PR DESCRIPTION
# Summary
Update a pinned gist to show your latest public HackMD notes.

# Description
This project dymamically updates a pinned gist to show your latest HackMD notes publicly published.
The gist includes a list of the notes' titles, with a separate Markdown file that provides clickable links to each article.

# Links
<!-- (required) -->

**GitHub Repo:** https://github.com/tsen159/hackmd-box
**Sample Gist:** https://gist.github.com/tsen159/10bf4ec688fbae7bc0879bbfb1d57fd7

# Screenshot of example gist
<img width="503" height="222" alt="demo" src="https://github.com/user-attachments/assets/5aa76312-2b6a-4515-aaa3-41af7a049d10" />

# Checklist
<!-- (required)
If done, insert a `x` between the brackets (ie, `[x]`).
If not done, leave empty (ie, `[ ]`).
-->

- [x] List item follows expected format (e.g. `[example-box](link) - Update a pinned gist to contain...`)
- [x] Pull request title is useful and clear
- [x] Pull request template is filled out
- [x] Pull request contains a single addition only
